### PR TITLE
#define IMGUI_DEFINE_MATH_OPERATORS

### DIFF
--- a/imgui_widget_flamegraph.cpp
+++ b/imgui_widget_flamegraph.cpp
@@ -20,10 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <imgui_widget_flamegraph.h>
+#define IMGUI_DEFINE_MATH_OPERATORS
 
 #include "imgui.h"
 #include "imgui_internal.h"
+
+#include <imgui_widget_flamegraph.h>
 
 void ImGuiWidgetFlameGraph::PlotFlame(const char* label, void (*values_getter)(float* start, float* end, ImU8* level, const char** caption, const void* data, int idx), const void* data, int values_count, int values_offset, const char* overlay_text, float scale_min, float scale_max, ImVec2 graph_size)
 {


### PR DESCRIPTION
#1 Define IMGUI_DEFINE_MATH_OPERATORS to get ImGui math overloads in the implementation file (.cpp). The "imgui_widget_flamegraph.h" include was moved because it itself includes "imgui.h" which needs to be included after the define.

More info: https://github.com/ocornut/imgui/issues/2832